### PR TITLE
Add a newline to end of the generated types file

### DIFF
--- a/src/createTypedefs.ts
+++ b/src/createTypedefs.ts
@@ -14,4 +14,8 @@ const ts = ['/* tslint:disable */', '/* eslint-disable */']
   .concat(JsonToTS(config, {rootName: 'Config'}))
   .join('\n')
 
-fs.writeFileSync(path.resolve(process.cwd(), baseConfigPath(process), file), ts)
+// Ensure the file generated finishes with a newline
+fs.writeFileSync(
+  path.resolve(process.cwd(), baseConfigPath(process), file),
+  `${ts}\n`
+)


### PR DESCRIPTION
Git will add a newline to files on commit, this causes Config.d.ts
to be always in a state of change as the generation removed the newline
and git adds it again. This change ensures there is always a newline
at the end.