### PR TITLE
Fix: Typings of webpack plugin function

### DIFF
--- a/webpack.ts
+++ b/webpack.ts
@@ -15,9 +15,9 @@ const setGlobalConfigPlugin = R.over(
   )
 )
 
-export const NodeConfigTSPlugin: {
-  (config: Configuration): Configuration
-} = R.compose(
+export const NodeConfigTSPlugin: (
+  config: Configuration
+) => Configuration = R.compose(
   setConfigResolver,
   setGlobalConfigPlugin
 )


### PR DESCRIPTION
What?
Fix for typings of `NodeConfigTSPlugin`. 

Current:
An object with a key of type `Configuration` and a value of same type.

After fix:
A function which takes in an object if type `Configuration` and returns an object of the same type.