### PR TITLE
feat(env-variables): load user config based on USER and USERNAME

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,10 @@ There are three directories in which a project can have configurations — `depl
 | --------------- | ------------------ |
 | NODE_ENV        | /config/env        |
 | DEPLOYMENT      | /config/deployment |
-| USER            | /config/user       |
+| USER (USERNAME) | /config/user       |
+
+User specific configuration is loaded based on `USER` env variable (UNIX way)
+or `USERNAME` env variable (Windows way).
 
 ### Using environment variables
 

--- a/src/configPaths.ts
+++ b/src/configPaths.ts
@@ -20,6 +20,7 @@ export type NonConfigEnv = {
     NODE_ENV?: string
     DEPLOYMENT?: string
     USER?: string
+    USERNAME?: string
     NODE_CONFIG_TS_DIR?: string
   }
 }
@@ -43,7 +44,9 @@ export const configPaths = <T extends NonConfigEnv>(
   )
   const userConfig = path.resolve(
     process.cwd(),
-    `${baseDIR}/user/${process.env['USER'] || DEFAULT_FILENAME}.json`
+    `${baseDIR}/user/${process.env['USER'] ||
+      process.env['USERNAME'] ||
+      DEFAULT_FILENAME}.json`
   )
   return {defaultConfig, envConfig, deploymentConfig, userConfig}
 }

--- a/test/configPaths.ts
+++ b/test/configPaths.ts
@@ -89,6 +89,29 @@ describe('config-paths', () => {
     })
   })
 
+  describe('USERNAME', () => {
+    it('should return actual config path', () => {
+      const process = {
+        env: {USERNAME: 'root'},
+        cwd: () => '/app/www.bravo.com/server'
+      }
+      const actual = configPaths(process).userConfig
+      const expected = '/app/www.bravo.com/server/config/user/root.json'
+
+      assert.deepEqual(actual, expected)
+    })
+    it('should return default config path', () => {
+      const process = {
+        env: {},
+        cwd: () => '/app/www.bravo.com/server'
+      }
+      const actual = configPaths(process).userConfig
+      const expected = '/app/www.bravo.com/server/config/user/default.json'
+
+      assert.deepEqual(actual, expected)
+    })
+  })
+
   describe('ENV:NODE_CONFIG_DIR', () => {
     it('should set base config dir', () => {
       const process = {


### PR DESCRIPTION
User specific configuration is loaded based on `USER` env variable (UNIX way)
or `USERNAME` env variable (Windows way).