### PR TITLE
feat: support for replacing embedded env var with both prefix and suffix of @@

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,20 +128,31 @@ or `USERNAME` env variable (Windows way).
 
 ### Using environment variables
 
-Whenever the value is prefixed with the letters `@@` **node-config-ts** automatically looks for an environment variable with that name. For example —
+Whenever the value is prefixed and/or suffixed with the letters `@@` **node-config-ts** automatically looks for an environment variable with that name. For example —
 
 ```json
 // default.json
 {
-  "port": "@@APP_PORT"
+  "port": "@@APP_PORT",
+  "url": "https://@@DOMAIN@@/home"
 }
 ```
 
-In the above case automatically the value of `port` is set to the value that's available inside the environment variable `PORT`.
+In the above case automatically the value of `port`, `url` is set to the value that's available inside the environment variable `PORT`, `DOMAIN`.
 
 ```bash
 export APP_PORT=3000
+export DOMAIN=test.com
 node server.js // server started with config.port as 3000
+```
+
+The final config resolves into
+
+```json
+{
+  "port": "3000",
+  "url": "https://test.com/home"
+}
 ```
 
 ### Custom Config Directory

--- a/test/replaceWithEnvVar.ts
+++ b/test/replaceWithEnvVar.ts
@@ -37,4 +37,23 @@ describe('replaceWithEnvVar', () => {
     const expected = {a: {b: {c: '5050'}}}
     assert.deepEqual(actual, expected)
   })
+
+  it('should update all embedded variables in base config with available env variables', () => {
+    const process = {
+      env: {
+        DOMAIN: 'test.com',
+        PATH: 'home'
+      }
+    }
+    const baseConfig = {
+      a: {
+        b: {
+          c: 'https://@@DOMAIN@@/@@PATH'
+        }
+      }
+    }
+    const actual = replaceWithEnvVar(baseConfig, process)
+    const expected = {a: {b: {c: 'https://test.com/home'}}}
+    assert.deepEqual(actual, expected)
+  })
 })


### PR DESCRIPTION
What?
Feature to support embedded var replace with env var.

Current:
@@PORT will get replaced with env value of 3000.

After feature:
@@PORT will get replaced with env value of 3000.
https://@@DOMAIN@@/graphql will get replaced with https://test.com/graphql