### PR TITLE
feat: Adding NODE_CONFIG_TS_ENV as an alternative to NODE_ENV

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,12 +119,14 @@ There are three directories in which a project can have configurations — `depl
 
 | **process.env** | **directory**      |
 | --------------- | ------------------ |
-| NODE_ENV        | /config/env        |
+| NODE_ENV | NODE_CONFIG_TS_ENV | /config/env        |
 | DEPLOYMENT      | /config/deployment |
 | USER (USERNAME) | /config/user       |
 
 User specific configuration is loaded based on `USER` env variable (UNIX way)
 or `USERNAME` env variable (Windows way).
+
+You can use NODE_CONFIG_TS_ENV as an alternative to NODE_ENV.
 
 ### Using environment variables
 

--- a/src/baseConfigPath.ts
+++ b/src/baseConfigPath.ts
@@ -7,6 +7,7 @@ type NonConfigTSEnv = {
   env: {
     NODE_CONFIG_TS_DIR?: string
     NODE_ENV?: string
+    NODE_CONFIG_TS_ENV?: string
   }
 }
 

--- a/src/configPaths.ts
+++ b/src/configPaths.ts
@@ -18,6 +18,7 @@ export type NonConfigEnv = {
   cwd(): string
   env: {
     NODE_ENV?: string
+    NODE_CONFIG_TS_ENV?: string
     DEPLOYMENT?: string
     USER?: string
     USERNAME?: string
@@ -33,9 +34,12 @@ export const configPaths = <T extends NonConfigEnv>(
     process.cwd(),
     `${baseDIR}/${DEFAULT_FILENAME}.json`
   )
+  const envConfigFile = `${process.env['NODE_CONFIG_TS_ENV'] ||
+    process.env['NODE_ENV'] ||
+    DEFAULT_FILENAME}`
   const envConfig = path.resolve(
     process.cwd(),
-    `${baseDIR}/env/${process.env['NODE_ENV'] || DEFAULT_FILENAME}.json`
+    `${baseDIR}/env/${envConfigFile}.json`
   )
   const deploymentConfig = path.resolve(
     process.cwd(),

--- a/test/loadFileConfigs.ts
+++ b/test/loadFileConfigs.ts
@@ -48,4 +48,44 @@ describe('load-file-configs', () => {
     }
     assert.deepEqual(actual, expected)
   })
+
+  describe('alternative env varialble', () => {
+    it('should load the configs that are available', () => {
+      const process = {
+        cwd: () => path.resolve(__dirname, 'stub-module'),
+        env: {
+          DEPLOYMENT: 'www.example.com',
+          NODE_CONFIG_TS_ENV: 'production',
+          USER: 'root'
+        }
+      }
+      const actual = loadFileConfigs(process)
+      const expected = {
+        defaultConfig,
+        deploymentConfig,
+        envConfig,
+        userConfig
+      }
+      assert.deepEqual(actual, expected)
+    })
+
+    it('should load default configs when not available', () => {
+      const process = {
+        cwd: () => path.resolve(__dirname, 'stub-module'),
+        env: {
+          DEPLOYMENT: 'www.example.com',
+          NODE_CONFIG_TS_ENV: 'development',
+          USER: 'root'
+        }
+      }
+      const actual = loadFileConfigs(process)
+      const expected = {
+        defaultConfig,
+        deploymentConfig,
+        envConfig: {},
+        userConfig
+      }
+      assert.deepEqual(actual, expected)
+    })
+  })
 })

--- a/test/mergeAllConfigs.ts
+++ b/test/mergeAllConfigs.ts
@@ -61,4 +61,65 @@ describe('mergeAllConfigs()', () => {
     }
     assert.deepEqual(actual, expected)
   })
+
+  describe('alternative env varialble', () => {
+    it('should load configs from all the places', () => {
+      const process = {
+        argv: [],
+        cwd: () => path.resolve(__dirname, 'stub-module'),
+        env: {
+          DEPLOYMENT: 'www.example.com',
+          NODE_CONFIG_TS_ENV: 'production',
+          USER: 'root',
+          MAX_RETRIES: 999
+        }
+      }
+      const actual = mergeAllConfigs(process)
+      const expected = {
+        type: 'user',
+        port: 9000,
+        maxRetries: 999
+      }
+      assert.deepEqual(actual, expected)
+    })
+    it('should override with cli configs', () => {
+      const process = {
+        argv: ['--port', '3000', '--wonder', 'woman'],
+        cwd: () => path.resolve(__dirname, 'stub-module'),
+        env: {
+          DEPLOYMENT: 'www.example.com',
+          NODE_CONFIG_TS_ENV: 'production',
+          USER: 'root',
+          MAX_RETRIES: 999
+        }
+      }
+      const actual = mergeAllConfigs(process)
+      const expected = {
+        type: 'user',
+        port: 3000,
+        wonder: 'woman',
+        maxRetries: 999
+      }
+      assert.deepEqual(actual, expected)
+    })
+    it('should override ENV variables with cli configs', () => {
+      const process = {
+        argv: ['--port', '3000', '--maxRetries', '150'],
+        cwd: () => path.resolve(__dirname, 'stub-module'),
+        env: {
+          DEPLOYMENT: 'www.example.com',
+          NODE_CONFIG_TS_ENV: 'production',
+          USER: 'root',
+          MAX_RETRIES: 999
+        }
+      }
+      const actual = mergeAllConfigs(process)
+      const expected = {
+        type: 'user',
+        port: 3000,
+        maxRetries: 150
+      }
+      assert.deepEqual(actual, expected)
+    })
+  })
 })


### PR DESCRIPTION
Allowing `NODE_CONFIG_TS_ENV` to be used instead of `NODE_ENV`. Mirroring `NODE_CONFIG_ENV` in `node-config`.