### PR TITLE
fix: type error in replaceWithEnvVar test

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,8 +1,16 @@
 /**
  * Created by tushar on 30/12/17.
  */
-import * as dotenv from 'dotenv'
 import {mergeAllConfigs} from './src/mergeAllConfigs'
 
-dotenv.config()
+// Try to load .env file. This will fail if dotenv is not installed. Note that
+// require() is used instead of import() because import() is asynchronous and we
+// need to load the config before the app starts. Also, ES6 import statements
+// can't be wrapped in a try/catch block.
+try {
+    require('dotenv').config()
+} catch (err) {
+    // ignore
+}
+
 export const config = mergeAllConfigs(process)

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "node-config-ts",
   "version": "0.0.0-development",
   "dependencies": {
-    "dotenv": "^16.0.3",
     "json-to-ts": "^1.6.0",
     "json5": "^2.2.2",
     "minimist": "^1.2.0",
@@ -11,7 +10,8 @@
   },
   "peerDependencies": {
     "@types/webpack": "4.x",
-    "webpack": "4.x"
+    "webpack": "4.x",
+    "dotenv": "^16.0.3"
   },
   "scripts": {
     "semantic-release": "semantic-release",

--- a/src/replaceWithEnvVar.ts
+++ b/src/replaceWithEnvVar.ts
@@ -9,12 +9,12 @@ const hasEnvVar = R.test(/^@@.*$/)
 
 type NodeENV = {
   env: {
-    [key: string]: string
+    [key: string]: string | undefined
   }
 }
 export const replaceWithEnvVar = <T, P extends NodeENV>(
   baseConfig: T,
-  process: P
+  process: P = { env: {} } as P
 ): T => {
   const itar: any = R.map((value: any) => {
     if (R.is(Object, value)) return itar(value)

--- a/test/__snapshots__/createTypedefCode-mergeAllConfigs.ts.snap
+++ b/test/__snapshots__/createTypedefCode-mergeAllConfigs.ts.snap
@@ -5,6 +5,7 @@ declare module "node-config-ts" {
     type: string
     port: number
     maxRetries: number
+    secret: undefined
   }
   export const config: Config
   export type Config = IConfig

--- a/test/createTypedefCode.ts
+++ b/test/createTypedefCode.ts
@@ -11,6 +11,8 @@ const snapshotDir = path.resolve(__dirname, '__snapshots__')
 describe('createTypedefCode(config)', () => {
   let actual: string
   let config: any
+  // This doesn't seem to work, needs investigation
+  const shouldUpdateSnapshots = process.argv.includes('-u')
 
   before(async () => {
     await fs.mkdir(snapshotDir, {recursive: true})
@@ -38,7 +40,7 @@ describe('createTypedefCode(config)', () => {
     })
 
     it('should match the expected snapshot', () => {
-      return assertMatchesSnapshot(actual, snapshotFile)
+      return assertMatchesSnapshot(actual, snapshotFile, shouldUpdateSnapshots)
     })
 
     it('should generate valid typescript', () => {

--- a/test/mergeAllConfigs.ts
+++ b/test/mergeAllConfigs.ts
@@ -18,7 +18,8 @@ describe('mergeAllConfigs()', () => {
     const expected = {
       type: 'user',
       port: 9000,
-      maxRetries: 999
+      maxRetries: 999,
+      secret: undefined
     }
     assert.deepEqual(actual, expected)
   })
@@ -38,7 +39,8 @@ describe('mergeAllConfigs()', () => {
       type: 'user',
       port: 3000,
       wonder: 'woman',
-      maxRetries: 999
+      maxRetries: 999,
+      secret: undefined
     }
     assert.deepEqual(actual, expected)
   })
@@ -50,19 +52,21 @@ describe('mergeAllConfigs()', () => {
         DEPLOYMENT: 'www.example.com',
         NODE_ENV: 'production',
         USER: 'root',
-        MAX_RETRIES: 999
+        MAX_RETRIES: 999,
+        secret: undefined
       }
     }
     const actual = mergeAllConfigs(process)
     const expected = {
       type: 'user',
       port: 3000,
-      maxRetries: 150
+      maxRetries: 150,
+      secret: undefined
     }
     assert.deepEqual(actual, expected)
   })
 
-  describe('alternative env varialble', () => {
+  describe('alternative env variable', () => {
     it('should load configs from all the places', () => {
       const process = {
         argv: [],
@@ -71,14 +75,16 @@ describe('mergeAllConfigs()', () => {
           DEPLOYMENT: 'www.example.com',
           NODE_CONFIG_TS_ENV: 'production',
           USER: 'root',
-          MAX_RETRIES: 999
+          MAX_RETRIES: 999,
+          secret: undefined
         }
       }
       const actual = mergeAllConfigs(process)
       const expected = {
         type: 'user',
         port: 9000,
-        maxRetries: 999
+        maxRetries: 999,
+        secret: undefined
       }
       assert.deepEqual(actual, expected)
     })
@@ -90,7 +96,8 @@ describe('mergeAllConfigs()', () => {
           DEPLOYMENT: 'www.example.com',
           NODE_CONFIG_TS_ENV: 'production',
           USER: 'root',
-          MAX_RETRIES: 999
+          MAX_RETRIES: 999,
+          secret: undefined
         }
       }
       const actual = mergeAllConfigs(process)
@@ -98,7 +105,8 @@ describe('mergeAllConfigs()', () => {
         type: 'user',
         port: 3000,
         wonder: 'woman',
-        maxRetries: 999
+        maxRetries: 999,
+        secret: undefined
       }
       assert.deepEqual(actual, expected)
     })
@@ -110,14 +118,15 @@ describe('mergeAllConfigs()', () => {
           DEPLOYMENT: 'www.example.com',
           NODE_CONFIG_TS_ENV: 'production',
           USER: 'root',
-          MAX_RETRIES: 999
+          MAX_RETRIES: 999,
         }
       }
       const actual = mergeAllConfigs(process)
       const expected = {
         type: 'user',
         port: 3000,
-        maxRetries: 150
+        maxRetries: 150,
+        secret: undefined
       }
       assert.deepEqual(actual, expected)
     })

--- a/test/replaceWithEnvVar.ts
+++ b/test/replaceWithEnvVar.ts
@@ -7,14 +7,16 @@ import * as dotenv from 'dotenv'
 
 describe('replaceWithEnvVar', () => {
   it('should take variables from dotenv file', () => {
-      const process = {
-        env: dotenv.config({path: 'test/.env'}).parsed
-      }
+    const parsed = dotenv.config({path: 'test/.env'}).parsed
+    assert(parsed != null, 'parsed is null or undefined')
+    const process = {
+      env: parsed as dotenv.DotenvParseOutput
+    }
 
-      const baseConfig = {
-        a: 'a',
-        b: '@@SECRET'
-      }
+    const baseConfig = {
+      a: 'a',
+      b: '@@SECRET'
+    }
     const actual = replaceWithEnvVar(baseConfig, process)
     const expected = {...baseConfig, b: 'TEST_SECRET'}
     assert.deepEqual(actual, expected)


### PR DESCRIPTION
This should fix the build failure causing CI to break.

- test: fix incorrect type causing builds to fail
- fix: make dotenv a peer dependency
- fix: surround dotenv import with try/catch in index.ts, in case consumer doesn't use dotenv
- test: update typegen snapshots
- test: update mergeAllConfig test cases