### PR TITLE
Refactor: drop `ramda`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,7 @@
         "json-to-ts": "^1.6.0",
         "json5": "^2.2.2",
         "minimist": "^1.2.0",
-        "prettier": "^2.8.0",
-        "ramda": "^0.27.0"
+        "prettier": "^2.8.0"
       },
       "bin": {
         "node-config-ts": "bin/cli"
@@ -25,7 +24,6 @@
         "@types/mocha": "^7.0.1",
         "@types/node": "^13.7.0",
         "@types/prettier": "^1.19.0",
-        "@types/ramda": "^0.26.40",
         "@types/webpack": "^4.41.5",
         "commitizen": "^4.2.6",
         "cz-conventional-changelog": "^3.1.0",
@@ -1926,14 +1924,6 @@
       "version": "1.19.0",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/ramda": {
-      "version": "0.26.40",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ts-toolbelt": "^4.12.0"
-      }
     },
     "node_modules/@types/retry": {
       "version": "0.12.0",
@@ -9466,10 +9456,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/ramda": {
-      "version": "0.27.0",
-      "license": "MIT"
-    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -11129,11 +11115,6 @@
       "engines": {
         "node": ">=0.3.1"
       }
-    },
-    "node_modules/ts-toolbelt": {
-      "version": "4.14.6",
-      "dev": true,
-      "license": "Apache-2.0"
     },
     "node_modules/tslib": {
       "version": "2.4.1",
@@ -13250,13 +13231,6 @@
     "@types/prettier": {
       "version": "1.19.0",
       "dev": true
-    },
-    "@types/ramda": {
-      "version": "0.26.40",
-      "dev": true,
-      "requires": {
-        "ts-toolbelt": "^4.12.0"
-      }
     },
     "@types/retry": {
       "version": "0.12.0",
@@ -18540,9 +18514,6 @@
       "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
       "dev": true
     },
-    "ramda": {
-      "version": "0.27.0"
-    },
     "randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -19711,10 +19682,6 @@
           "optional": true
         }
       }
-    },
-    "ts-toolbelt": {
-      "version": "4.14.6",
-      "dev": true
     },
     "tslib": {
       "version": "2.4.1",

--- a/package.json
+++ b/package.json
@@ -22,8 +22,7 @@
     "json-to-ts": "^1.6.0",
     "json5": "^2.2.2",
     "minimist": "^1.2.0",
-    "prettier": "^2.8.0",
-    "ramda": "^0.27.0"
+    "prettier": "^2.8.0"
   },
   "peerDependencies": {
     "webpack": "4.x || 5.x",
@@ -40,7 +39,6 @@
     "@types/mocha": "^7.0.1",
     "@types/node": "^13.7.0",
     "@types/prettier": "^1.19.0",
-    "@types/ramda": "^0.26.40",
     "@types/webpack": "^4.41.5",
     "commitizen": "^4.2.6",
     "cz-conventional-changelog": "^3.1.0",

--- a/src/loadCliConfigs.ts
+++ b/src/loadCliConfigs.ts
@@ -3,7 +3,6 @@
  */
 
 import minimist = require('minimist')
-import * as R from 'ramda'
 
 type ProcessArgv = {
   argv: string[]
@@ -15,5 +14,7 @@ type ProcessArgv = {
  * @return {{cliConfig: any}}
  */
 export const loadCLIConfigs = <T extends ProcessArgv>(process: T) => {
-  return R.omit(['_'], minimist(process.argv))
+  // omit _ from the parsed args
+  const { _: _, ...rest } = minimist(process.argv)
+  return rest;
 }

--- a/src/loadFileConfigs.ts
+++ b/src/loadFileConfigs.ts
@@ -4,11 +4,10 @@
  * Created by tushar on 30/12/17.
  */
 import * as fs from 'fs'
-import * as R from 'ramda'
 import * as JSON5 from 'json5'
 import {configPaths, ConfigTypes, NonConfigEnv} from './configPaths'
 
-const readAndParse = R.pipe((file: string) => fs.readFileSync(file, 'utf8'), JSON5.parse)
+const readAndParse = (file: string) => JSON5.parse(fs.readFileSync(file, 'utf8'))
 
 export type Configurations<T> = {[key in keyof T]: any}
 
@@ -21,8 +20,16 @@ export type Configurations<T> = {[key in keyof T]: any}
 export const loadFileConfigs = <T extends NonConfigEnv>(
   process: T
 ): Configurations<ConfigTypes> => {
-  const itar: any = R.mapObjIndexed(
-    R.ifElse(fs.existsSync, readAndParse, R.always({}))
-  )
-  return itar(configPaths(process))
+  const paths = configPaths(process)
+
+  const configs: Record<string, any> = {}
+
+  Object.entries(paths).forEach(([key, path]) => {
+    configs[key] = {};
+    if (fs.existsSync(path)) {
+      configs[key] = readAndParse(path)
+    }
+  })
+
+  return configs as Configurations<ConfigTypes>
 }

--- a/src/mergeAllConfigs.ts
+++ b/src/mergeAllConfigs.ts
@@ -1,19 +1,27 @@
 /**
  * Created by tushar on 30/12/17.
  */
-import R = require('ramda')
 import {loadCLIConfigs} from './loadCliConfigs'
 import {loadFileConfigs} from './loadFileConfigs'
 import {replaceWithEnvVar} from './replaceWithEnvVar'
 import {mergeFileConfigs} from './mergeFileConfigs'
+import {mergeDeepRight} from './mergeDeepRight';
+
+interface Process {
+  argv: string[],
+  cwd: () => string,
+  env: {
+    [key: string]: string | undefined
+  }
+}
 
 /**
  * Loads all the configs from files and cli and merges them.
  */
-export const mergeAllConfigs = R.converge(R.mergeDeepRight, [
-  R.converge(replaceWithEnvVar, [
-    R.compose(mergeFileConfigs, loadFileConfigs),
-    R.identity
-  ]),
-  loadCLIConfigs
-])
+export const mergeAllConfigs = (process: Process) => {
+  const fileConfigs = mergeFileConfigs(loadFileConfigs(process))
+  const mergedWithEnvVar = replaceWithEnvVar(fileConfigs, process)
+  const cliConfigs = loadCLIConfigs(process)
+
+  return mergeDeepRight(mergedWithEnvVar, cliConfigs)
+}

--- a/src/mergeAllConfigs.ts
+++ b/src/mergeAllConfigs.ts
@@ -10,9 +10,7 @@ import {mergeDeepRight} from './mergeDeepRight';
 interface Process {
   argv: string[],
   cwd: () => string,
-  env: {
-    [key: string]: string | undefined
-  }
+  env: NodeJS.ProcessEnv
 }
 
 /**

--- a/src/mergeDeepRight.ts
+++ b/src/mergeDeepRight.ts
@@ -1,0 +1,10 @@
+export const mergeDeepRight = (a: any, b: any): any => {
+    if (a === undefined) return b
+    if (b === undefined) return a
+    if (typeof a === 'object' && typeof b === 'object') {
+        return Object.keys({...a, ...b}).reduce((acc, key) => {
+            return {...acc, [key]: mergeDeepRight(a[key], b[key])}
+        }, {})
+    }
+    return b
+}

--- a/src/mergeFileConfigs.ts
+++ b/src/mergeFileConfigs.ts
@@ -1,4 +1,13 @@
-import * as R from 'ramda'
+const mergeDeepRight = (a: any, b: any): any => {
+  if (a === undefined) return b
+  if (b === undefined) return a
+  if (typeof a === 'object' && typeof b === 'object') {
+    return Object.keys({...a, ...b}).reduce((acc, key) => {
+      return {...acc, [key]: mergeDeepRight(a[key], b[key])}
+    }, {})
+  }
+  return b
+}
 
 /**
  * Merges the configs in the following order —
@@ -6,11 +15,13 @@ import * as R from 'ramda'
  * @param {ConfigSources} configs
  * @return {any}
  */
-
 export const mergeFileConfigs = (configs: {[key: string]: any}) => {
-  return R.reduce(R.mergeDeepRight, configs.defaultConfig, [
+  const configsOrder = [
+    configs.defaultConfig,
     configs.envConfig,
     configs.deploymentConfig,
-    configs.userConfig
-  ])
+    configs.userConfig,
+  ];
+
+  return configsOrder.reduce(mergeDeepRight, {})
 }

--- a/src/mergeFileConfigs.ts
+++ b/src/mergeFileConfigs.ts
@@ -1,13 +1,4 @@
-const mergeDeepRight = (a: any, b: any): any => {
-  if (a === undefined) return b
-  if (b === undefined) return a
-  if (typeof a === 'object' && typeof b === 'object') {
-    return Object.keys({...a, ...b}).reduce((acc, key) => {
-      return {...acc, [key]: mergeDeepRight(a[key], b[key])}
-    }, {})
-  }
-  return b
-}
+import {mergeDeepRight} from './mergeDeepRight';
 
 /**
  * Merges the configs in the following order —

--- a/test/__snapshots__/createTypedefCode-mergeAllConfigs.ts.snap
+++ b/test/__snapshots__/createTypedefCode-mergeAllConfigs.ts.snap
@@ -4,7 +4,7 @@ declare module "node-config-ts" {
   interface IConfig {
     type: string
     port: number
-    maxRetries: number
+    maxRetries: string
     secret: undefined
   }
   export const config: Config

--- a/test/createTypedefCode.ts
+++ b/test/createTypedefCode.ts
@@ -58,7 +58,7 @@ describe('createTypedefCode(config)', () => {
   })
 })
 
-const getDiagnostics = (source: string) =>
+const getDiagnostics = (source: string) => 
   ts.transpileModule(source, {
           compilerOptions: {
             module: ts.ModuleKind.CommonJS,
@@ -67,12 +67,12 @@ const getDiagnostics = (source: string) =>
         }).diagnostics ?? []
 /**
  * Simple snapshot testing.
- *
+ * 
  * @param actual Returned text from tested function
  * @param snapshotFile name of snapshot file. Not a path.
  * @param update updates the snapshot if `actual` doesn't match
- *
- * @returns
+ * 
+ * @returns 
  */
 const assertMatchesSnapshot = async (
   actual: string,

--- a/test/createTypedefCode.ts
+++ b/test/createTypedefCode.ts
@@ -29,7 +29,7 @@ describe('createTypedefCode(config)', () => {
           DEPLOYMENT: 'www.example.com',
           NODE_ENV: 'production',
           USER: 'root',
-          MAX_RETRIES: 999
+          MAX_RETRIES: '999'
         }
       }
       config = mergeAllConfigs(process)
@@ -58,7 +58,7 @@ describe('createTypedefCode(config)', () => {
   })
 })
 
-const getDiagnostics = (source: string) => 
+const getDiagnostics = (source: string) =>
   ts.transpileModule(source, {
           compilerOptions: {
             module: ts.ModuleKind.CommonJS,
@@ -67,12 +67,12 @@ const getDiagnostics = (source: string) =>
         }).diagnostics ?? []
 /**
  * Simple snapshot testing.
- * 
+ *
  * @param actual Returned text from tested function
  * @param snapshotFile name of snapshot file. Not a path.
  * @param update updates the snapshot if `actual` doesn't match
- * 
- * @returns 
+ *
+ * @returns
  */
 const assertMatchesSnapshot = async (
   actual: string,

--- a/test/mergeAllConfigs.ts
+++ b/test/mergeAllConfigs.ts
@@ -11,7 +11,7 @@ describe('mergeAllConfigs()', () => {
         DEPLOYMENT: 'www.example.com',
         NODE_ENV: 'production',
         USER: 'root',
-        MAX_RETRIES: 999
+        MAX_RETRIES: '999'
       }
     }
     const actual = mergeAllConfigs(process)
@@ -31,7 +31,7 @@ describe('mergeAllConfigs()', () => {
         DEPLOYMENT: 'www.example.com',
         NODE_ENV: 'production',
         USER: 'root',
-        MAX_RETRIES: 999
+        MAX_RETRIES: '999'
       }
     }
     const actual = mergeAllConfigs(process)
@@ -52,7 +52,7 @@ describe('mergeAllConfigs()', () => {
         DEPLOYMENT: 'www.example.com',
         NODE_ENV: 'production',
         USER: 'root',
-        MAX_RETRIES: 999,
+        MAX_RETRIES: '999',
         secret: undefined
       }
     }
@@ -75,7 +75,7 @@ describe('mergeAllConfigs()', () => {
           DEPLOYMENT: 'www.example.com',
           NODE_CONFIG_TS_ENV: 'production',
           USER: 'root',
-          MAX_RETRIES: 999,
+          MAX_RETRIES: '999',
           secret: undefined
         }
       }
@@ -96,7 +96,7 @@ describe('mergeAllConfigs()', () => {
           DEPLOYMENT: 'www.example.com',
           NODE_CONFIG_TS_ENV: 'production',
           USER: 'root',
-          MAX_RETRIES: 999,
+          MAX_RETRIES: '999',
           secret: undefined
         }
       }
@@ -118,7 +118,7 @@ describe('mergeAllConfigs()', () => {
           DEPLOYMENT: 'www.example.com',
           NODE_CONFIG_TS_ENV: 'production',
           USER: 'root',
-          MAX_RETRIES: 999,
+          MAX_RETRIES: '999',
         }
       }
       const actual = mergeAllConfigs(process)

--- a/webpack.ts
+++ b/webpack.ts
@@ -1,22 +1,26 @@
 import {config} from './index'
 import {DefinePlugin, Configuration} from 'webpack'
-import * as R from 'ramda'
 
-const setConfigResolver = R.assocPath<string, Configuration>(
-  ['resolve', 'alias', 'node-config-ts'],
-  'node-config-ts/iso'
-)
-const setGlobalConfigPlugin = R.over(
-  R.lensProp('plugins'),
-  R.append(
+const setConfigResolver = (webpackConfig: Configuration) => {
+  webpackConfig.resolve = webpackConfig.resolve || {}
+  webpackConfig.resolve.alias = webpackConfig.resolve.alias || {}
+
+  const alias = webpackConfig.resolve.alias as {[key: string]: string};
+  alias['node-config-ts'] = 'node-config-ts/iso'
+
+  return webpackConfig
+}
+
+const setGlobalConfigPlugin = (webpackConfig: Configuration) => {
+  webpackConfig.plugins = webpackConfig.plugins || []
+  webpackConfig.plugins.push(
     new DefinePlugin({
-      __CONFIG__: JSON.stringify(config)
+      __CONFIG__: JSON.stringify(config),
     })
   )
-)
 
-export const NodeConfigTSPlugin = R.compose<
-  Configuration,
-  Configuration,
-  Configuration
->(setConfigResolver, setGlobalConfigPlugin)
+  return webpackConfig
+}
+
+export const NodeConfigTSPlugin = (config: Configuration) =>
+  setGlobalConfigPlugin(setConfigResolver(config))


### PR DESCRIPTION
I also had to change `MAX_RETRIES: 999` to `MAX_RETRIES: '999'` in the mocked `process.env` to comply with the types of environment variables being `string`s

Closes: #83 